### PR TITLE
Fix: Close sidebars when pressing tab and out of the sidebar

### DIFF
--- a/src/modules/code-collabo/components/SM_Screen_FiltersSideBar.tsx
+++ b/src/modules/code-collabo/components/SM_Screen_FiltersSideBar.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import React, { useRef } from 'react';
+import useCloseSidebarOnClickOutside from '../hooks/useCloseSidebarOnClickOutside';
+import useCloseSidebarOnTabOut from '../hooks/useCloseSidebarOnTabOut';
 import useScreenDimensions from '../hooks/useScreenDimensions';
 import FiltersComponent from './Filters';
 import Overlay from './Overlay';
@@ -8,6 +10,12 @@ import SM_Screen_FilterHamburgerComponent from './SM_Screen_FilterHamburger';
 export default function SM_Screen_FiltersSideBarComponent({ isFilterOpen, toggleFilter }: { isFilterOpen: boolean; toggleFilter?: () => void  }) {
   const  { is_sm_screen }  = useScreenDimensions();
   const is_SM_Screen_FilterSidebarToggleTrue = is_sm_screen && isFilterOpen;
+
+  const sidebarRef = useRef<HTMLDivElement>(null);
+
+  useCloseSidebarOnClickOutside(sidebarRef, toggleFilter);
+
+  useCloseSidebarOnTabOut(!!toggleFilter, toggleFilter as () => void);
 
   // Filter sidebar should show and open for SM-screen-devices when filter is open
   if (is_SM_Screen_FilterSidebarToggleTrue) {

--- a/src/modules/code-collabo/components/SideBar.tsx
+++ b/src/modules/code-collabo/components/SideBar.tsx
@@ -1,12 +1,21 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import useScreenDimensions from '../hooks/useScreenDimensions';
 import SM_Screen_HamburgerComponent from './SM_Screen_Hamburger';
 import Overlay from './Overlay';
+import useCloseSidebarOnTabOut from '../hooks/useCloseSidebarOnTabOut';
+import useCloseSidebarOnClickOutside from '../hooks/useCloseSidebarOnClickOutside';
 
 function SideBarComponent({ toggleSidebar }: { toggleSidebar?: () => void; }) {
   const { is_midAndUp_screens }  = useScreenDimensions();
+
+  const sidebarRef = useRef<HTMLDivElement>(null);
+
+  useCloseSidebarOnClickOutside(sidebarRef, toggleSidebar);
+
+  useCloseSidebarOnTabOut(!!toggleSidebar, toggleSidebar as () => void);
+  
   return (
     <>
       {/* Sidebar for MidAndUp-screens & left side menu for SM-screen-devices */}

--- a/src/modules/code-collabo/hooks/useCloseSidebarOnClickOutside.tsx
+++ b/src/modules/code-collabo/hooks/useCloseSidebarOnClickOutside.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+const useCloseSidebarOnClickOutside = (sidebarRef: React.RefObject<HTMLDivElement>, toggleSidebar?: () => void) => {
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (sidebarRef.current && !sidebarRef.current.contains(event.target as Node)) {
+        toggleSidebar?.();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [sidebarRef, toggleSidebar]);
+};
+
+export default useCloseSidebarOnClickOutside;

--- a/src/modules/code-collabo/hooks/useCloseSidebarOnTabOut.tsx
+++ b/src/modules/code-collabo/hooks/useCloseSidebarOnTabOut.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from 'react';
+
+const useCloseSidebarOnTabOut = (isOpen: boolean, toggleSidebar: () => void) => {
+  const lastFocusableElementRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (isOpen && event.key === 'Tab') {
+        const sidebar = document.querySelector('.app__side-menubar');
+        const focusableElements = sidebar?.querySelectorAll(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+
+        if (focusableElements) {
+          const firstFocusableElement = focusableElements[0] as HTMLElement;
+          const lastFocusableElement = focusableElements[focusableElements.length - 1] as HTMLElement;
+          if (event.shiftKey && document.activeElement === firstFocusableElement) {
+            lastFocusableElement.focus();
+          } else if (!event.shiftKey && document.activeElement === lastFocusableElement) {
+            firstFocusableElement.focus();
+            toggleSidebar();
+          }
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, toggleSidebar]);
+
+  return lastFocusableElementRef;
+};
+
+export default useCloseSidebarOnTabOut;


### PR DESCRIPTION
**This pull request makes the following changes**
* Fixes Closing the sidebars (Hamburger & filter) when Tab is used to navigate after the last element on the sidebar. 

**General checklist**
- [X] File or folder now contains changes as specified in the issue i worked on
- [X] I have linked the issue I worked on to this pull request submitted by me

**Testing checklist**

Replace this text with the testing checklist from the issue this pull request fixes.
- [X] The design is responsive and implemented as stated in the issue description.
 - [X] Accessibility is left/implemented as stated in the issue description.
 - [X] No external library is used
 - [X] I certify that I ran my checklist
 - [X] I certify that I ran my checklist

Ping @code-collabo/web-app

